### PR TITLE
Change default to work on windows

### DIFF
--- a/src/main/java/com/google/dart/AbstractDartMojo.java
+++ b/src/main/java/com/google/dart/AbstractDartMojo.java
@@ -80,7 +80,16 @@ public abstract class AbstractDartMojo extends AbstractDeployMojo {
 
 	protected List<String> getCompileSourceRoots() {
 		if (compileSourceRoots.isEmpty()) {
-			return Collections.singletonList(getBasedir() + "/src/main/dart");
+			
+			final StringBuilder defaultPath = new StringBuilder(); // /src/main/dart or \src\main\dart
+			defaultPath.append(File.separator);
+			defaultPath.append("src");
+			defaultPath.append(File.separator);
+			defaultPath.append("main");
+			defaultPath.append(File.separator);
+			defaultPath.append("dart"); 
+			
+			return Collections.singletonList(getBasedir() + defaultPath.toString());
 		}
 		return compileSourceRoots;
 	}


### PR DESCRIPTION
Before this change, if a default source was not supplied, any comparison using path.startsWith() will fail, because it will be comparing the windows path (c:\foo\bar\src\main\dart) with the hard-coded string (c:\foo\bar/src/main/dart).  This change builds up the string using the correct path separator.
