### PR TITLE
--global-js-name option support

### DIFF
--- a/src/main/java/com/google/dart/Dart2JsMojo.java
+++ b/src/main/java/com/google/dart/Dart2JsMojo.java
@@ -109,15 +109,15 @@ public class Dart2JsMojo
 	 */
 	private final static String ARGUMENT_DIAGNOSTIC_COLORS = "--enable-diagnostic-colors";
 
-    /**
-     * Name of the global variable used by dart2js compiler in the generated code.
-     * The name must match the regular expression "\$[a-z]*".
-     *
-     * @since 2.1.2
-     */
-    private final static String ARGUMENT_GLOBAL_JS_NAME = "--global-js-name=";
+	/**
+	 * Name of the global variable used by dart2js compiler in the generated code.
+	 * The name must match the regular expression "\$[a-z]*".
+	 *
+	 * @since 2.1.2
+	 */
+	private final static String ARGUMENT_GLOBAL_JS_NAME = "--global-js-name=";
 
-    /**
+	/**
 	 * Skip the execution of dart2js.
 	 *
 	 * @since 1.1
@@ -393,7 +393,7 @@ public class Dart2JsMojo
 			cl.createArg().setValue(ARGUMENT_PACKAGE_PATH + packagePath.getAbsolutePath());
 		}
 
-        cl.createArg().setValue(ARGUMENT_GLOBAL_JS_NAME + globalJsName);
+		cl.createArg().setValue(ARGUMENT_GLOBAL_JS_NAME + globalJsName);
 
 		if (getLog().isDebugEnabled()) {
 			getLog().debug("Base dart2js command: " + cl.toString());


### PR DESCRIPTION
Default global variable name for in JS code generated by dart2js is $, which clashes with other JS libraries, such as jQuery. It's really helpful to be able to specify it in Maven configs.
