### PR TITLE
test file at end of command line, so that options like '--checked' are respected

### DIFF
--- a/src/main/java/com/google/dart/TestMojo.java
+++ b/src/main/java/com/google/dart/TestMojo.java
@@ -92,7 +92,7 @@ public class TestMojo extends DartMojo {
 
         final Commandline cl = createBaseCommandline();
 
-        final Arg scriptArg = cl.createArg(true);
+        final Arg scriptArg = cl.createArg(false);
 
         final StreamConsumer output = new WriterStreamConsumer(new OutputStreamWriter(System.out));
         final StreamConsumer error = new WriterStreamConsumer(new OutputStreamWriter(System.err));


### PR DESCRIPTION
The latest dart command (v 1.10.0) expects switches prior to executable file.  For example, consider this simple test code:
```
library hello_test;

import "package:test/test.dart";

void main() {
  test("A test that intentionally fails", () {
    String str = 1 + 2;
  });
}
```

Running ```dart --checked hello_test.dart``` results in the expected failure whereas running ```dart hello_test.dart --checked``` ignores the ```--checked``` flag and incorrectly passes the test.