### PR TITLE
Dart command update

### DIFF
--- a/dart-maven-plugin-example/pom.xml
+++ b/dart-maven-plugin-example/pom.xml
@@ -47,7 +47,7 @@
             <plugin>
                 <groupId>com.github.dzwicker.dart</groupId>
                 <artifactId>dart-maven-plugin</artifactId>
-                <version>3.0.9-SNAPSHOT</version>
+                <version>3.0.11</version>
                 <configuration>
                     <checkedMode>true</checkedMode>
                     <dartSdk>${dart.sdk}</dartSdk>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>com.github.dzwicker.dart</groupId>
     <artifactId>dart-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>3.0.10-SNAPSHOT</version>
+    <version>3.0.11</version>
     <name>Dart Maven Plugin</name>
     <description>Maven Plugin to manage dart SDK operations</description>
     <url>http://dzwicker.github.com/dart-maven-plugin/</url>
@@ -59,7 +59,7 @@
     <properties>
         <github.global.server>github</github.global.server>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.7</java.version>
+        <java.version>1.8</java.version>
     </properties>
 
     <build>

--- a/src/main/java/com/google/dart/DartMojo.java
+++ b/src/main/java/com/google/dart/DartMojo.java
@@ -14,6 +14,7 @@ import org.codehaus.plexus.util.cli.WriterStreamConsumer;
 
 import java.io.File;
 import java.io.OutputStreamWriter;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -130,6 +131,17 @@ public class DartMojo extends PubMojo {
     @Parameter(defaultValue = "false", property = "dart.pup.skip")
     private boolean skipPub;
 
+    @Parameter(
+            property = "customPackagePath",
+            defaultValue = "false"
+    )
+    private boolean customPackageRoot;
+
+    @Parameter(
+            property = "arguments"
+    )
+    private List<String> arguments;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
 
@@ -149,10 +161,16 @@ public class DartMojo extends PubMojo {
             throw new IllegalArgumentException("Script must be a file. scripte=" + script.getAbsolutePath());
         }
         if (!script.canRead()) {
-            throw new IllegalArgumentException("Script must be a readable file. scripte=" + script.getAbsolutePath());
+            throw new IllegalArgumentException("Script must be a readable file. script=" + script.getAbsolutePath());
         }
 
         cl.createArg(true).setValue(script.getAbsolutePath());
+        if (!this.arguments.isEmpty()) {
+
+            for (String arg : this.arguments) {
+                cl.createArg().setValue(arg);
+            }
+        }
 
         final StreamConsumer output = new WriterStreamConsumer(new OutputStreamWriter(System.out));
         final StreamConsumer error = new WriterStreamConsumer(new OutputStreamWriter(System.err));
@@ -208,7 +226,9 @@ public class DartMojo extends PubMojo {
             cl.createArg().setValue(ARGUMENT_USE_SCRIPT_SNAPSHOT + useScriptSnapshot);
         }
 
-        cl.createArg().setValue(buildPackagePath());
+        if (this.customPackageRoot) {
+            cl.createArg().setValue(this.buildPackagePath());
+        };
 
         if (getLog().isDebugEnabled()) {
             getLog().debug("Base dart command: " + cl.toString());

--- a/src/main/java/com/google/dart/PubMojo.java
+++ b/src/main/java/com/google/dart/PubMojo.java
@@ -54,10 +54,10 @@ public class PubMojo extends AbstractDartMojo {
         }
         String pubPath;
         checkPub();
-        pubPath = getPubExecutable().getAbsolutePath();
+        pubPath = getDartExecutable().getAbsolutePath();
 
         if (getLog().isDebugEnabled()) {
-            getLog().debug("Using pub '" + pubPath + "'.");
+            getLog().debug("Using dart '" + pubPath + "'.");
             getLog().debug("basedir: " + getBasedir());
         }
 
@@ -67,6 +67,7 @@ public class PubMojo extends AbstractDartMojo {
         final Commandline cl = new Commandline();
         cl.setExecutable(pubPath);
 
+        cl.createArg().setValue("pub");
         cl.createArg().setValue(pubCommand);
 
         if (pubOptions != null) {
@@ -107,14 +108,14 @@ public class PubMojo extends AbstractDartMojo {
 
     protected void checkPub() throws MojoExecutionException {
         checkDartSdk();
-        if (!getPubExecutable().canExecute()) {
+        if (!getDartExecutable().canExecute()) {
             throw new MojoExecutionException("Pub not executable! Configuration error for dartSdk? dartSdk="
                 + getDartSdk().getAbsolutePath());
         }
     }
 
-    private File getPubExecutable() {
-        return new File(getDartSdk(), "bin/pub" + (OsUtil.isWindows() ? ".bat" : ""));
+    private File getDartExecutable() {
+        return new File(getDartSdk(), "bin/dart" + (OsUtil.isWindows() ? ".exe" : ""));
     }
 
     public boolean isPubSkipped() {


### PR DESCRIPTION
Update how the tool invokes the `pub` tool to conform to the latest Dart SDK requirements (namely that `pub` is now deprecated and should be invoked as a subcommand of `dart`).

Closes #59 